### PR TITLE
Extend for unsteady problems

### DIFF
--- a/fem/mms.py
+++ b/fem/mms.py
@@ -19,19 +19,21 @@ def verify_spatial_order_of_accuracy(
             
             s = self.strong_form_residual(self.manufactured_solution())
             
+            V = self.function_space
+            
+            if hasattr(self, "time"):
+                
+                s = fe.interpolate(fe.Expression(s, t = self.time), V)
+            
             try:
             
-                for psi, s_i in zip(fe.TestFunctions(self.function_space), s):
-                    
-                    if hasattr(self, "time"):
-                    
-                        s_i.t = self.time
+                for psi, s_i in zip(fe.TestFunctions(V), s):
                     
                     r -= fe.inner(psi, s_i)
                     
             except NotImplementedError as error:
             
-                psi = fe.TestFunction(self.function_space)
+                psi = fe.TestFunction(V)
                 
                 r -= fe.inner(psi, s)
                 
@@ -41,13 +43,11 @@ def verify_spatial_order_of_accuracy(
             
             u_m = self.manufactured_solution()
             
+            V = self.function_space
+            
             if hasattr(self, "time"):
             
-                u_m = fe.Expression(u_m)
-            
-                u_m.t = self.time
-            
-            V = self.function_space
+                u_m = fe.interpolate(fe.Expression(u_m, t = self.time), V)
             
             try:
     

--- a/fem/model.py
+++ b/fem/model.py
@@ -47,7 +47,9 @@ class Model(metaclass = abc.ABCMeta):
         self.solution = fe.Function(self.function_space)
     
     def init_dirichlet_boundary_conditions(self):
-        """ Either set to None or a tuple of `fe.DirichletBC """
+        """ Optionallay redefine this 
+        to set `self.dirichlet_boundary_conditions`
+        to a tuple of `fe.DirichletBC` """
         self.dirichlet_boundary_conditions = None
         
     def init_integration_measure(self):

--- a/fem/model.py
+++ b/fem/model.py
@@ -15,51 +15,64 @@ class Model(metaclass = abc.ABCMeta):
         
         self.init_solution()
         
-        self.integration_measure = fe.dx
+        self.init_integration_measure()
+        
+        self.init_weak_form_residual()
+        
+        self.init_dirichlet_boundary_conditions()
+        
+        self.init_problem()
+        
+        self.init_solver()
     
     @abc.abstractmethod
     def init_mesh(self):
-        """ Redefine this to return a `fe.Mesh`.
+        """ Redefine this to set `self.mesh` to a `fe.Mesh`.
         """
     
     @abc.abstractmethod
     def init_element(self):
-        """ Redefine this to return a `fe.FiniteElement` or `fe.MixedElement`.
+        """ Redefine this to set `self.element` 
+        to a  `fe.FiniteElement` or `fe.MixedElement`.
         """
         
     @abc.abstractmethod
-    def weak_form_residual(self):
-        """ Redefine this to return a `fe.NonlinearVariationalForm`.
+    def init_weak_form_residual(self):
+        """ Redefine this to set `self.weak_form_residual` 
+        to a `fe.NonlinearVariationalForm`.
         """
-    
+        
     def init_solution(self):
     
         self.solution = fe.Function(self.function_space)
     
-    def dirichlet_boundary_conditions(self):
-        """ Optionally redefine this to return a tuple of `fe.DirichletBC`.
-        """
-        return None
+    def init_dirichlet_boundary_conditions(self):
+        """ Either set to None or a tuple of `fe.DirichletBC """
+        self.dirichlet_boundary_conditions = None
         
-    def solve(self,
-            solver_parameters = {
+    def init_integration_measure(self):
+
+        self.integration_measure = fe.dx
+        
+    def init_problem(self):
+    
+        r = self.weak_form_residual*self.integration_measure
+        
+        u = self.solution
+        
+        bcs = self.dirichlet_boundary_conditions
+        
+        self.problem = fe.NonlinearVariationalProblem(
+            r, u, bcs, fe.derivative(r, u))
+        
+    def init_solver(self, solver_parameters = {
                 "ksp_type": "preonly", 
                 "pc_type": "lu", 
                 "mat_type": "aij",
                 "pc_factor_mat_solver_type": "mumps"}):
-    
-        r = self.weak_form_residual()*self.integration_measure
         
-        u = self.solution
-        
-        bcs = self.dirichlet_boundary_conditions()
-        
-        problem = fe.NonlinearVariationalProblem(r, u, bcs, fe.derivative(r, u))
-        
-        solver = fe.NonlinearVariationalSolver(
-            problem, solver_parameters = solver_parameters)
-        
-        solver.solve()
+        self.solver = fe.NonlinearVariationalSolver(
+            self.problem, solver_parameters = solver_parameters)
     
     def unit_vectors(self):
         

--- a/fem/model.py
+++ b/fem/model.py
@@ -60,10 +60,8 @@ class Model(metaclass = abc.ABCMeta):
         
         u = self.solution
         
-        bcs = self.dirichlet_boundary_conditions
-        
         self.problem = fe.NonlinearVariationalProblem(
-            r, u, bcs, fe.derivative(r, u))
+            r, u, self.dirichlet_boundary_conditions, fe.derivative(r, u))
         
     def init_solver(self, solver_parameters = {
                 "ksp_type": "preonly", 

--- a/fem/models/__init__.py
+++ b/fem/models/__init__.py
@@ -2,3 +2,4 @@ from . import laplace
 from . import convection_diffusion
 from . import navier_stokes
 from . import navier_stokes_boussinesq
+from . import heat

--- a/fem/models/convection_diffusion.py
+++ b/fem/models/convection_diffusion.py
@@ -7,15 +7,15 @@ class Model(fem.model.Model):
     
     def __init__(self):
     
-        super().__init__()
-        
         self.kinematic_viscosity = fe.Constant(1.)
+    
+        super().__init__()
         
     def init_element(self):
     
         self.element = fe.FiniteElement("P", self.mesh.ufl_cell(), 1)
     
-    def weak_form_residual(self):
+    def init_weak_form_residual(self):
         
         u, v = self.solution, fe.TestFunction(self.solution.function_space())
         
@@ -27,5 +27,5 @@ class Model(fem.model.Model):
         
         dot, grad = fe.dot, fe.grad
         
-        return v*dot(a, grad(u)) + dot(grad(v), nu*grad(u))
+        self.weak_form_residual = v*dot(a, grad(u)) + dot(grad(v), nu*grad(u))
         

--- a/fem/models/heat.py
+++ b/fem/models/heat.py
@@ -7,15 +7,15 @@ class Model(fem.unsteady_model.UnsteadyModel):
     
     def __init__(self):
         
-        super().__init__()
-        
         self.thermal_diffusivity = fe.Constant(1.)
+        
+        super().__init__()
         
     def init_element(self):
     
         self.element = fe.FiniteElement("P", self.mesh.ufl_cell(), 1)
     
-    def weak_form_residual(self):
+    def init_weak_form_residual(self):
         
         alpha = self.thermal_diffusivity
         
@@ -31,5 +31,5 @@ class Model(fem.unsteady_model.UnsteadyModel):
         
         dot, grad = fe.dot, fe.grad
         
-        return v*u_t + alpha*dot(grad(v), grad(u))
+        self.weak_form_residual = v*u_t + alpha*dot(grad(v), grad(u))
     

--- a/fem/models/heat.py
+++ b/fem/models/heat.py
@@ -1,0 +1,35 @@
+""" A heat model class """
+import firedrake as fe
+import fem.unsteady_model
+
+    
+class Model(fem.unsteady_model.UnsteadyModel):
+    
+    def __init__(self):
+        
+        super().__init__()
+        
+        self.thermal_diffusivity = fe.Constant(1.)
+        
+    def init_element(self):
+    
+        self.element = fe.FiniteElement("P", self.mesh.ufl_cell(), 1)
+    
+    def weak_form_residual(self):
+        
+        alpha = self.thermal_diffusivity
+        
+        u = self.solution
+        
+        un = self.initial_values
+        
+        Delta_t = self.timestep_size
+        
+        u_t = (u - un)/Delta_t
+        
+        v = fe.TestFunction(self.function_space)
+        
+        dot, grad = fe.dot, fe.grad
+        
+        return v*u_t + alpha*dot(grad(v), grad(u))
+    

--- a/fem/models/heat.py
+++ b/fem/models/heat.py
@@ -13,15 +13,23 @@ class Model(fem.unsteady_model.UnsteadyModel):
     
         self.element = fe.FiniteElement("P", self.mesh.ufl_cell(), 1)
     
+    def init_time_derivative(self):
+        """ Implicit Euler finite difference scheme """
+        u = self.solution
+        
+        un = self.initial_values[0]
+        
+        Delta_t = self.timestep_size
+        
+        self.time_derivative = (u - un)/Delta_t
+    
     def init_weak_form_residual(self):
         
         u = self.solution
         
-        un = self.initial_values
+        self.init_time_derivative()
         
-        Delta_t = self.timestep_size
-        
-        u_t = (u - un)/Delta_t
+        u_t = self.time_derivative
         
         v = fe.TestFunction(self.function_space)
         

--- a/fem/models/heat.py
+++ b/fem/models/heat.py
@@ -7,8 +7,6 @@ class Model(fem.unsteady_model.UnsteadyModel):
     
     def __init__(self):
         
-        self.thermal_diffusivity = fe.Constant(1.)
-        
         super().__init__()
         
     def init_element(self):
@@ -16,8 +14,6 @@ class Model(fem.unsteady_model.UnsteadyModel):
         self.element = fe.FiniteElement("P", self.mesh.ufl_cell(), 1)
     
     def init_weak_form_residual(self):
-        
-        alpha = self.thermal_diffusivity
         
         u = self.solution
         
@@ -31,5 +27,5 @@ class Model(fem.unsteady_model.UnsteadyModel):
         
         dot, grad = fe.dot, fe.grad
         
-        self.weak_form_residual = v*u_t + alpha*dot(grad(v), grad(u))
+        self.weak_form_residual = v*u_t + dot(grad(v), grad(u))
     

--- a/fem/models/laplace.py
+++ b/fem/models/laplace.py
@@ -10,7 +10,7 @@ class Model(fem.model.Model):
     
         self.element = fe.FiniteElement("P", self.mesh.ufl_cell(), 1)
     
-    def weak_form_residual(self):
+    def init_weak_form_residual(self):
         
         u = self.solution
         
@@ -18,5 +18,4 @@ class Model(fem.model.Model):
         
         dot, grad = fe.dot, fe.grad
         
-        return - dot(grad(v), grad(u))
-    
+        self.weak_form_residual = - dot(grad(v), grad(u))

--- a/fem/models/navier_stokes.py
+++ b/fem/models/navier_stokes.py
@@ -15,7 +15,7 @@ class Model(fem.model.Model):
             fe.VectorElement('P', self.mesh.ufl_cell(), 2),
             fe.FiniteElement('P', self.mesh.ufl_cell(), 1))
     
-    def weak_form_residual(self):
+    def init_weak_form_residual(self):
 
         inner, dot, grad, div, sym = \
             fe.inner, fe.dot, fe.grad, fe.div, fe.sym
@@ -29,5 +29,5 @@ class Model(fem.model.Model):
         momentum = dot(psi_u, dot(grad(u), u)) - div(psi_u)*p + \
             2.*inner(sym(grad(psi_u)), sym(grad(u)))
         
-        return mass + momentum
+        self.weak_form_residual = mass + momentum
     

--- a/fem/models/navier_stokes_boussinesq.py
+++ b/fem/models/navier_stokes_boussinesq.py
@@ -7,20 +7,16 @@ class Model(fem.model.Model):
     
     def __init__(self):
     
-        super().__init__()
-        
         self.dynamic_viscosity = fe.Constant(1.)
         
         self.rayleigh_number = fe.Constant(1.)
         
         self.prandtl_number = fe.Constant(1.)
         
-        ihat, jhat = self.unit_vectors()
-        
-        self.gravity_direction = fe.Constant(-jhat)
-        
         self.pressure_penalty_factor = fe.Constant(1.e-7)
-    
+        
+        super().__init__()
+        
     def init_element(self):
     
         self.element = fe.MixedElement(
@@ -28,13 +24,17 @@ class Model(fem.model.Model):
             fe.VectorElement("P", self.mesh.ufl_cell(), 2),
             fe.FiniteElement("P", self.mesh.ufl_cell(), 1))
     
-    def weak_form_residual(self):
+    def init_weak_form_residual(self):
 
         mu = self.dynamic_viscosity
         
         Ra = self.rayleigh_number
         
         Pr = self.prandtl_number
+        
+        ihat, jhat = self.unit_vectors()
+        
+        self.gravity_direction = fe.Constant(-jhat)
         
         ghat = self.gravity_direction
         
@@ -56,4 +56,4 @@ class Model(fem.model.Model):
         
         stabilization = psi_p*gamma*p
         
-        return mass + momentum + energy + stabilization
+        self.weak_form_residual = mass + momentum + energy + stabilization

--- a/fem/table.py
+++ b/fem/table.py
@@ -57,4 +57,8 @@ class Table:
             string += format_row(self.row(i))
             
         return string
+        
+    def max(self, key):
+    
+        return max(list(filter(None.__ne__, self.data[key])))
    

--- a/fem/unsteady_model.py
+++ b/fem/unsteady_model.py
@@ -1,0 +1,38 @@
+""" An abstract class on which to base finite element models
+with auxiliary data for unsteady (i.e. time-dependent) simulations.
+"""
+import firedrake as fe
+import fem.model
+
+
+class UnsteadyModel(fem.model.Model):
+    """ An abstract class on which to base finite element models
+        with auxiliary data for unsteady (i.e. time-dependent) simulations.
+    """
+    def __init__(self):
+        
+        self.time = None
+        
+        self.ufl_time = fe.variable(0.)
+        
+        self.timestep_size = fe.Constant(1.)
+        
+        super().__init__()
+        
+    def init_solution(self):
+    
+        super().init_solution()
+        
+        self.initial_values = fe.Function(self.function_space)
+        
+    def set_initial_values(self, initial_values):
+    
+        if type(initial_values) is type(self.initial_values):
+        
+            self.initial_values.assign(initial_values)
+            
+        else:
+            
+            self.initial_values.assign(fe.interpolate(
+                initial_values, self.function_space))
+           

--- a/fem/unsteady_model.py
+++ b/fem/unsteady_model.py
@@ -11,9 +11,7 @@ class UnsteadyModel(fem.model.Model):
     """
     def __init__(self):
         
-        self.time = None
-        
-        self.ufl_time = fe.variable(0.)
+        self.time = fe.Constant(0.)
         
         self.timestep_size = fe.Constant(1.)
         
@@ -24,15 +22,3 @@ class UnsteadyModel(fem.model.Model):
         super().init_solution()
         
         self.initial_values = fe.Function(self.function_space)
-        
-    def set_initial_values(self, initial_values):
-    
-        if type(initial_values) is type(self.initial_values):
-        
-            self.initial_values.assign(initial_values)
-            
-        else:
-            
-            self.initial_values.assign(fe.interpolate(
-                initial_values, self.function_space))
-           

--- a/fem/unsteady_model.py
+++ b/fem/unsteady_model.py
@@ -21,4 +21,5 @@ class UnsteadyModel(fem.model.Model):
     
         super().init_solution()
         
-        self.initial_values = fe.Function(self.function_space)
+        self.initial_values = [fe.Function(self.function_space),]
+        

--- a/tests/test__convection_diffusion.py
+++ b/tests/test__convection_diffusion.py
@@ -3,7 +3,7 @@ import fem
 
 
 def test__verify_convergence_order_via_mms(
-        grid_sizes = (16, 32), tolerance = 0.1):
+        grid_sizes = (16, 32), tolerance = 0.1, quadrature_degree = 2):
     
     class Model(fem.models.convection_diffusion.Model):
         
@@ -12,24 +12,30 @@ def test__verify_convergence_order_via_mms(
             self.gridsize = gridsize
             
             super().__init__()
-            
-            self.integration_measure = fe.dx(degree = 2)
-            
-            x = fe.SpatialCoordinate(self.mesh)
-            
-            sin, pi = fe.sin, fe.pi
-            
-            ihat, jhat = self.unit_vectors()
-            
-            self.advection_velocity = sin(2.*pi*x[0])*sin(4.*pi*x[1])*ihat \
-                + sin(pi*x[0])*sin(2.*pi*x[1])*jhat
                 
             self.kinematic_viscosity.assign(0.1)
             
         def init_mesh(self):
             
             self.mesh = fe.UnitSquareMesh(self.gridsize, self.gridsize)
-    
+        
+        def init_integration_measure(self):
+
+            self.integration_measure = fe.dx(degree = 2)
+        
+        def init_manufactured_solution(self):
+            
+            x = fe.SpatialCoordinate(self.mesh)
+            
+            sin, pi = fe.sin, fe.pi
+            
+            self.manufactured_solution = sin(2.*pi*x[0])*sin(pi*x[1])
+            
+            ihat, jhat = self.unit_vectors()
+            
+            self.advection_velocity = sin(2.*pi*x[0])*sin(4.*pi*x[1])*ihat \
+                + sin(pi*x[0])*sin(2.*pi*x[1])*jhat
+        
         def strong_form_residual(self, solution):
             
             x = fe.SpatialCoordinate(self.mesh)
@@ -44,16 +50,9 @@ def test__verify_convergence_order_via_mms(
             
             return dot(a, grad(u)) - div(nu*grad(u))
         
-        def manufactured_solution(self):
-            
-            x = fe.SpatialCoordinate(self.mesh)
-            
-            sin, pi = fe.sin, fe.pi
-            
-            return sin(2.*pi*x[0])*sin(pi*x[1])
-    
     fem.mms.verify_spatial_order_of_accuracy(
         Model = Model,
         expected_order = 2,
         grid_sizes = grid_sizes,
-        tolerance = tolerance)
+        tolerance = tolerance,
+        quadrature_degree = quadrature_degree)

--- a/tests/test__convection_diffusion.py
+++ b/tests/test__convection_diffusion.py
@@ -2,7 +2,8 @@ import firedrake as fe
 import fem
 
 
-def test__verify_convergence_order_via_mms():
+def test__verify_convergence_order_via_mms(
+        grid_sizes = (16, 32), tolerance = 0.1):
     
     class Model(fem.models.convection_diffusion.Model):
         
@@ -29,11 +30,11 @@ def test__verify_convergence_order_via_mms():
             
             self.mesh = fe.UnitSquareMesh(self.gridsize, self.gridsize)
     
-        def strong_form_residual(self):
+        def strong_form_residual(self, solution):
             
             x = fe.SpatialCoordinate(self.mesh)
             
-            u = self.manufactured_solution()
+            u = solution
             
             a = self.advection_velocity
             
@@ -51,8 +52,8 @@ def test__verify_convergence_order_via_mms():
             
             return sin(2.*pi*x[0])*sin(pi*x[1])
     
-    fem.mms.verify_order_of_accuracy(
+    fem.mms.verify_spatial_order_of_accuracy(
         Model = Model,
-        expected_spatial_order = 2,
-        grid_sizes = (8, 16, 32),
-        tolerance = 0.1)
+        expected_order = 2,
+        grid_sizes = grid_sizes,
+        tolerance = tolerance)

--- a/tests/test__convection_diffusion.py
+++ b/tests/test__convection_diffusion.py
@@ -54,5 +54,4 @@ def test__verify_convergence_order_via_mms(
         Model = Model,
         expected_order = 2,
         grid_sizes = grid_sizes,
-        tolerance = tolerance,
-        quadrature_degree = quadrature_degree)
+        tolerance = tolerance)

--- a/tests/test__heat.py
+++ b/tests/test__heat.py
@@ -2,7 +2,8 @@ import firedrake as fe
 import fem
 
 
-def test__verify_convergence_order_via_mms():
+def test__verify_convergence_order_via_mms(
+        grid_sizes = (16, 32), timestep_sizes = (1., 1./2., 1./4.), tolerance = 0.1):
     
     class Model(fem.models.heat.Model):
     
@@ -16,22 +17,26 @@ def test__verify_convergence_order_via_mms():
             
             self.thermal_diffusivity.assign(3.)
             
+            self.timestep_size.assign(max(timestep_sizes))
+            
+            self.time = 1.
+            
         def init_mesh(self):
         
             self.mesh = fe.UnitSquareMesh(self.gridsize, self.gridsize)
-        
-        def strong_form_residual(self):
+            
+        def strong_form_residual(self, solution):
             
             alpha = self.thermal_diffusivity
             
-            u = self.manufactured_solution()
+            u = solution
             
             t = self.ufl_time
             
             diff, div, grad = fe.diff, fe.div, fe.grad
             
             return diff(u, t) - alpha*div(grad(u))
-    
+        
         def manufactured_solution(self):
             
             x = fe.SpatialCoordinate(self.mesh)
@@ -42,19 +47,26 @@ def test__verify_convergence_order_via_mms():
             
             return sin(2.*pi*x[0])*sin(pi*x[1])*exp(-t)
         
+        def init_solution(self):
+        
+            super().init_solution()        
+        
+            u = fe.Expression(self.manufactured_solution())
+            
+            u.t = self.time
+            
+            self.set_initial_values(u)
+        
     fem.mms.verify_spatial_order_of_accuracy(
         Model = Model,
         expected_order = 2,
-        timestep_size = 1./4.,
-        endtime = 1.,
         grid_sizes = (8, 16, 32),
-        tolerance = 0.1)
-        
+        tolerance = tolerance)
+    
     fem.mms.verify_temporal_order_of_accuracy(
         Model = Model,
         expected_order = 1,
-        grid_size = 32,
+        gridsize = max(grid_sizes),
         endtime = 1.,
         timestep_sizes = (1., 1./2., 1./4.),
-        tolerance = 0.1)
-
+        tolerance = tolerance)

--- a/tests/test__heat.py
+++ b/tests/test__heat.py
@@ -10,8 +10,6 @@ class Model(fem.models.heat.Model):
         
         super().__init__()
         
-        self.thermal_diffusivity.assign(3.)
-        
     def init_mesh(self):
     
         self.mesh = fe.UnitIntervalMesh(self.gridsize)
@@ -22,15 +20,13 @@ class Model(fem.models.heat.Model):
         
     def strong_form_residual(self, solution):
         
-        alpha = self.thermal_diffusivity
-        
         u = solution
         
         t = self.time
         
         diff, div, grad = fe.diff, fe.div, fe.grad
         
-        return diff(u, t) - alpha*div(grad(u))
+        return diff(u, t) - div(grad(u))
     
     def init_manufactured_solution(self):
         
@@ -44,25 +40,22 @@ class Model(fem.models.heat.Model):
 
             
 def test__verify_spatial_convergence_order_via_mms(
-        grid_sizes = (8, 16),
-        timestep_size = 1./16.,
-        tolerance = 0.1,
-        quadrature_degree = 2):
+        grid_sizes = (4, 8, 16, 32),
+        timestep_size = 1./64.,
+        tolerance = 0.1):
     
     fem.mms.verify_spatial_order_of_accuracy(
         Model = Model,
         expected_order = 2,
         grid_sizes = grid_sizes,
         tolerance = tolerance,
-        quadrature_degree = quadrature_degree,
         timestep_size = timestep_size)
         
         
 def test__verify_temporal_convergence_order_via_mms(
-        gridsize = 16, 
-        timestep_sizes = (1./8., 1./16.),
-        tolerance = 0.1,
-        quadrature_degree = 2):
+        gridsize = 256,
+        timestep_sizes = (1./4., 1./8., 1./16., 1./32.),
+        tolerance = 0.1):
     
     fem.mms.verify_temporal_order_of_accuracy(
         Model = Model,
@@ -70,5 +63,4 @@ def test__verify_temporal_convergence_order_via_mms(
         gridsize = gridsize,
         endtime = 1.,
         timestep_sizes = timestep_sizes,
-        tolerance = tolerance,
-        quadrature_degree = quadrature_degree)
+        tolerance = tolerance)

--- a/tests/test__heat.py
+++ b/tests/test__heat.py
@@ -1,0 +1,60 @@
+import firedrake as fe 
+import fem
+
+
+def test__verify_convergence_order_via_mms():
+    
+    class Model(fem.models.heat.Model):
+    
+        def __init__(self, gridsize = 4):
+        
+            self.gridsize = gridsize
+            
+            super().__init__()
+            
+            self.integration_measure = fe.dx(degree = 2)
+            
+            self.thermal_diffusivity.assign(3.)
+            
+        def init_mesh(self):
+        
+            self.mesh = fe.UnitSquareMesh(self.gridsize, self.gridsize)
+        
+        def strong_form_residual(self):
+            
+            alpha = self.thermal_diffusivity
+            
+            u = self.manufactured_solution()
+            
+            t = self.ufl_time
+            
+            diff, div, grad = fe.diff, fe.div, fe.grad
+            
+            return diff(u, t) - alpha*div(grad(u))
+    
+        def manufactured_solution(self):
+            
+            x = fe.SpatialCoordinate(self.mesh)
+            
+            t = self.ufl_time
+            
+            sin, pi, exp = fe.sin, fe.pi, fe.exp
+            
+            return sin(2.*pi*x[0])*sin(pi*x[1])*exp(-t)
+        
+    fem.mms.verify_spatial_order_of_accuracy(
+        Model = Model,
+        expected_order = 2,
+        timestep_size = 1./4.,
+        endtime = 1.,
+        grid_sizes = (8, 16, 32),
+        tolerance = 0.1)
+        
+    fem.mms.verify_temporal_order_of_accuracy(
+        Model = Model,
+        expected_order = 1,
+        grid_size = 32,
+        endtime = 1.,
+        timestep_sizes = (1., 1./2., 1./4.),
+        tolerance = 0.1)
+

--- a/tests/test__heat.py
+++ b/tests/test__heat.py
@@ -2,69 +2,74 @@ import firedrake as fe
 import fem
 
 
-def test__verify_convergence_order_via_mms(
-        grid_sizes = (16, 32), timestep_sizes = (1., 1./2., 1./4.), tolerance = 0.1):
+class Model(fem.models.heat.Model):
     
-    class Model(fem.models.heat.Model):
+    def __init__(self, gridsize):
     
-        def __init__(self, gridsize = 4):
+        self.gridsize = gridsize
         
-            self.gridsize = gridsize
-            
-            super().__init__()
-            
+        super().__init__()
+        
+        self.thermal_diffusivity.assign(3.)
+        
+    def init_mesh(self):
+    
+        self.mesh = fe.UnitSquareMesh(self.gridsize, self.gridsize)
+        
+    def init_integration_measure(self):
+
             self.integration_measure = fe.dx(degree = 2)
-            
-            self.thermal_diffusivity.assign(3.)
-            
-            self.timestep_size.assign(max(timestep_sizes))
-            
-            self.time = 1.
-            
-        def init_mesh(self):
         
-            self.mesh = fe.UnitSquareMesh(self.gridsize, self.gridsize)
-            
-        def strong_form_residual(self, solution):
-            
-            alpha = self.thermal_diffusivity
-            
-            u = solution
-            
-            t = self.ufl_time
-            
-            diff, div, grad = fe.diff, fe.div, fe.grad
-            
-            return diff(u, t) - alpha*div(grad(u))
+    def strong_form_residual(self, solution):
         
-        def manufactured_solution(self):
-            
-            x = fe.SpatialCoordinate(self.mesh)
-            
-            t = self.ufl_time
-            
-            sin, pi, exp = fe.sin, fe.pi, fe.exp
-            
-            return sin(2.*pi*x[0])*sin(pi*x[1])*exp(-t)
+        alpha = self.thermal_diffusivity
         
-        def init_solution(self):
+        u = solution
         
-            super().init_solution()        
+        t = self.time
         
-            u = fe.Expression(self.manufactured_solution(), t = self.time)
+        diff, div, grad = fe.diff, fe.div, fe.grad
+        
+        return diff(u, t) - alpha*div(grad(u))
+    
+    def init_manufactured_solution(self):
+        
+        x = fe.SpatialCoordinate(self.mesh)
+        
+        t = self.time
+        
+        sin, pi, exp = fe.sin, fe.pi, fe.exp
+        
+        self.manufactured_solution = \
+            sin(2.*pi*x[0])*sin(pi*x[1])*exp(-pow(t, 2))
+
             
-            self.set_initial_values(fe.interpolate(u, self.function_space))
-        
+def test__verify_spatial_convergence_order_via_mms(
+        grid_sizes = (16, 32), 
+        timestep_size = 1./32.,
+        tolerance = 0.1,
+        quadrature_degree = 2):
+    
     fem.mms.verify_spatial_order_of_accuracy(
         Model = Model,
         expected_order = 2,
-        grid_sizes = (8, 16, 32),
-        tolerance = tolerance)
+        grid_sizes = grid_sizes,
+        tolerance = tolerance,
+        quadrature_degree = quadrature_degree,
+        timestep_size = timestep_size)
+        
+        
+def test__verify_temporal_convergence_order_via_mms(
+        gridsize = 32, 
+        timestep_sizes = (1./16., 1./32.),
+        tolerance = 0.1,
+        quadrature_degree = 2):
     
     fem.mms.verify_temporal_order_of_accuracy(
         Model = Model,
         expected_order = 1,
-        gridsize = max(grid_sizes),
+        gridsize = gridsize,
         endtime = 1.,
-        timestep_sizes = (1., 1./2., 1./4.),
-        tolerance = tolerance)
+        timestep_sizes = timestep_sizes,
+        tolerance = tolerance,
+        quadrature_degree = quadrature_degree)

--- a/tests/test__heat.py
+++ b/tests/test__heat.py
@@ -51,11 +51,9 @@ def test__verify_convergence_order_via_mms(
         
             super().init_solution()        
         
-            u = fe.Expression(self.manufactured_solution())
+            u = fe.Expression(self.manufactured_solution(), t = self.time)
             
-            u.t = self.time
-            
-            self.set_initial_values(u)
+            self.set_initial_values(fe.interpolate(u, self.function_space))
         
     fem.mms.verify_spatial_order_of_accuracy(
         Model = Model,

--- a/tests/test__heat.py
+++ b/tests/test__heat.py
@@ -14,11 +14,11 @@ class Model(fem.models.heat.Model):
         
     def init_mesh(self):
     
-        self.mesh = fe.UnitSquareMesh(self.gridsize, self.gridsize)
+        self.mesh = fe.UnitIntervalMesh(self.gridsize)
         
     def init_integration_measure(self):
 
-            self.integration_measure = fe.dx(degree = 2)
+            self.integration_measure = fe.dx
         
     def strong_form_residual(self, solution):
         
@@ -34,19 +34,18 @@ class Model(fem.models.heat.Model):
     
     def init_manufactured_solution(self):
         
-        x = fe.SpatialCoordinate(self.mesh)
+        x = fe.SpatialCoordinate(self.mesh)[0]
         
         t = self.time
         
         sin, pi, exp = fe.sin, fe.pi, fe.exp
         
-        self.manufactured_solution = \
-            sin(2.*pi*x[0])*sin(pi*x[1])*exp(-pow(t, 2))
+        self.manufactured_solution = sin(2.*pi*x)*exp(-pow(t, 2))
 
             
 def test__verify_spatial_convergence_order_via_mms(
-        grid_sizes = (16, 32), 
-        timestep_size = 1./32.,
+        grid_sizes = (8, 16),
+        timestep_size = 1./16.,
         tolerance = 0.1,
         quadrature_degree = 2):
     
@@ -60,8 +59,8 @@ def test__verify_spatial_convergence_order_via_mms(
         
         
 def test__verify_temporal_convergence_order_via_mms(
-        gridsize = 32, 
-        timestep_sizes = (1./16., 1./32.),
+        gridsize = 16, 
+        timestep_sizes = (1./8., 1./16.),
         tolerance = 0.1,
         quadrature_degree = 2):
     

--- a/tests/test__heat.py
+++ b/tests/test__heat.py
@@ -16,7 +16,7 @@ class Model(fem.models.heat.Model):
         
     def init_integration_measure(self):
 
-            self.integration_measure = fe.dx
+        self.integration_measure = fe.dx
         
     def strong_form_residual(self, solution):
         
@@ -38,7 +38,39 @@ class Model(fem.models.heat.Model):
         
         self.manufactured_solution = sin(2.*pi*x)*exp(-pow(t, 2))
 
-            
+        
+class SecondOrderModel(Model):
+
+    def init_solution(self):
+    
+        super().init_solution()
+        
+        self.initial_values.append(fe.Function(self.function_space))
+        
+    def init_time_derivative(self):
+        """ Gear/BDF2 finite difference scheme 
+        with constant time step size. """
+        unp1 = self.solution
+        
+        un = self.initial_values[0]
+        
+        unm1 = self.initial_values[1]
+        
+        Delta_t = self.timestep_size
+        
+        self.time_derivative = 1./Delta_t*(3./2.*unp1 - 2.*un + 0.5*unm1)
+        
+    def init_manufactured_solution(self):
+        
+        x = fe.SpatialCoordinate(self.mesh)[0]
+        
+        t = self.time
+        
+        sin, pi, exp = fe.sin, fe.pi, fe.exp
+        
+        self.manufactured_solution = sin(2.*pi*x)*exp(-pow(t, 3))
+
+        
 def test__verify_spatial_convergence_order_via_mms(
         grid_sizes = (4, 8, 16, 32),
         timestep_size = 1./64.,
@@ -64,3 +96,18 @@ def test__verify_temporal_convergence_order_via_mms(
         endtime = 1.,
         timestep_sizes = timestep_sizes,
         tolerance = tolerance)
+    
+    
+def test__verify_bdf2_temporal_convergence_order_via_mms(
+        gridsize = 256,
+        timestep_sizes = (1./2., 1./4., 1./8., 1./16.),
+        tolerance = 0.1):
+    
+    fem.mms.verify_temporal_order_of_accuracy(
+        Model = SecondOrderModel,
+        expected_order = 2,
+        gridsize = gridsize,
+        endtime = 1.,
+        timestep_sizes = timestep_sizes,
+        tolerance = tolerance)
+        

--- a/tests/test__laplace.py
+++ b/tests/test__laplace.py
@@ -2,7 +2,8 @@ import firedrake as fe
 import fem
 
 
-def test__verify_convergence_order_via_mms():
+def test__verify_convergence_order_via_mms(
+        grid_sizes = (16, 32), tolerance = 0.1):
 
     class Model(fem.models.laplace.Model):
     
@@ -18,11 +19,11 @@ def test__verify_convergence_order_via_mms():
             
             self.mesh = fe.UnitSquareMesh(self.gridsize, self.gridsize)
             
-        def strong_form_residual(self):
+        def strong_form_residual(self, solution):
         
             div, grad, = fe.div, fe.grad
             
-            u = self.manufactured_solution()
+            u = solution
             
             return div(grad(u))
         
@@ -34,17 +35,9 @@ def test__verify_convergence_order_via_mms():
             
             return sin(2.*pi*x[0])*sin(pi*x[1])
     
-    fem.mms.verify_order_of_accuracy(
+    fem.mms.verify_spatial_order_of_accuracy(
         Model = Model,
-        expected_spatial_order = 2,
-        grid_sizes = (8, 16, 32),
-        tolerance = 0.1)
+        expected_order = 2,
+        grid_sizes = grid_sizes,
+        tolerance = tolerance)
     
-    
-if __name__ == "__main__":
-
-    print("Using Python " + sys.version)
-
-    print("Using " + fe.__name__ + "-" + fe.__version__)
-    
-    test__verify_convergence_order_via_mms()

--- a/tests/test__laplace.py
+++ b/tests/test__laplace.py
@@ -19,6 +19,14 @@ def test__verify_convergence_order_via_mms(
             
             self.mesh = fe.UnitSquareMesh(self.gridsize, self.gridsize)
             
+        def init_manufactured_solution(self):
+            
+            sin, pi = fe.sin, fe.pi
+            
+            x = fe.SpatialCoordinate(self.mesh)
+            
+            self.manufactured_solution = sin(2.*pi*x[0])*sin(pi*x[1])
+            
         def strong_form_residual(self, solution):
         
             div, grad, = fe.div, fe.grad
@@ -26,14 +34,6 @@ def test__verify_convergence_order_via_mms(
             u = solution
             
             return div(grad(u))
-        
-        def manufactured_solution(self):
-            
-            sin, pi = fe.sin, fe.pi
-            
-            x = fe.SpatialCoordinate(self.mesh)
-            
-            return sin(2.*pi*x[0])*sin(pi*x[1])
     
     fem.mms.verify_spatial_order_of_accuracy(
         Model = Model,

--- a/tests/test__laplace.py
+++ b/tests/test__laplace.py
@@ -17,15 +17,15 @@ def test__verify_convergence_order_via_mms(
             
         def init_mesh(self):
             
-            self.mesh = fe.UnitSquareMesh(self.gridsize, self.gridsize)
+            self.mesh = fe.UnitIntervalMesh(self.gridsize)
             
         def init_manufactured_solution(self):
             
             sin, pi = fe.sin, fe.pi
             
-            x = fe.SpatialCoordinate(self.mesh)
+            x = fe.SpatialCoordinate(self.mesh)[0]
             
-            self.manufactured_solution = sin(2.*pi*x[0])*sin(pi*x[1])
+            self.manufactured_solution = sin(2.*pi*x)
             
         def strong_form_residual(self, solution):
         

--- a/tests/test__navier_stokes.py
+++ b/tests/test__navier_stokes.py
@@ -2,7 +2,8 @@ import firedrake as fe
 import fem
 
 
-def test__verify_convergence_order_via_MMS():
+def test__verify_convergence_order_via_MMS(
+        grid_sizes = (16, 32), tolerance = 0.1):
 
     class Model(fem.models.navier_stokes.Model):
     
@@ -18,11 +19,11 @@ def test__verify_convergence_order_via_MMS():
             
             self.mesh = fe.UnitSquareMesh(self.gridsize, self.gridsize)
             
-        def strong_form_residual(self):
+        def strong_form_residual(self, solution):
         
             grad, dot, div, sym = fe.grad, fe.dot, fe.div, fe.sym
             
-            u, p = self.manufactured_solution()
+            u, p = solution
             
             r_u = grad(u)*u + grad(p) - 2.*div(sym(grad(u)))
             
@@ -45,9 +46,9 @@ def test__verify_convergence_order_via_MMS():
             
             return u, p
     
-    fem.mms.verify_order_of_accuracy(
+    fem.mms.verify_spatial_order_of_accuracy(
         Model = Model,
-        expected_spatial_order = 2,
-        grid_sizes = (8, 16, 32),
-        tolerance = 0.1)
+        expected_order = 2,
+        grid_sizes = grid_sizes,
+        tolerance = tolerance)
     

--- a/tests/test__navier_stokes.py
+++ b/tests/test__navier_stokes.py
@@ -52,6 +52,5 @@ def test__verify_convergence_order_via_MMS(
         Model = Model,
         expected_order = 2,
         grid_sizes = grid_sizes,
-        tolerance = tolerance,
-        quadrature_degree = 4)
+        tolerance = tolerance)
     

--- a/tests/test__navier_stokes.py
+++ b/tests/test__navier_stokes.py
@@ -13,25 +13,15 @@ def test__verify_convergence_order_via_MMS(
             
             super().__init__()
             
-            self.integration_measure = fe.dx(degree = 4)
-            
         def init_mesh(self):
             
             self.mesh = fe.UnitSquareMesh(self.gridsize, self.gridsize)
-            
-        def strong_form_residual(self, solution):
         
-            grad, dot, div, sym = fe.grad, fe.dot, fe.div, fe.sym
+        def init_integration_measure(self):
+
+            self.integration_measure = fe.dx(degree = 4)
             
-            u, p = solution
-            
-            r_u = grad(u)*u + grad(p) - 2.*div(sym(grad(u)))
-            
-            r_p = div(u)
-            
-            return r_u, r_p
-        
-        def manufactured_solution(self):
+        def init_manufactured_solution(self):
             
             sin, pi = fe.sin, fe.pi
             
@@ -44,11 +34,24 @@ def test__verify_convergence_order_via_MMS(
             
             p = -0.5*(u[0]**2 + u[1]**2)
             
-            return u, p
-    
+            self.manufactured_solution = u, p
+        
+        def strong_form_residual(self, solution):
+        
+            grad, dot, div, sym = fe.grad, fe.dot, fe.div, fe.sym
+            
+            u, p = solution
+            
+            r_u = grad(u)*u + grad(p) - 2.*div(sym(grad(u)))
+            
+            r_p = div(u)
+            
+            return r_u, r_p
+        
     fem.mms.verify_spatial_order_of_accuracy(
         Model = Model,
         expected_order = 2,
         grid_sizes = grid_sizes,
-        tolerance = tolerance)
+        tolerance = tolerance,
+        quadrature_degree = 4)
     

--- a/tests/test__navier_stokes_boussinesq.py
+++ b/tests/test__navier_stokes_boussinesq.py
@@ -2,7 +2,8 @@ import firedrake as fe
 import fem
 
 
-def test__verify_convergence_order_via_MMS():
+def test__verify_convergence_order_via_MMS(
+        grid_sizes = (16, 32), tolerance = 0.1):
     
     class Model(fem.models.navier_stokes_boussinesq.Model):
     
@@ -30,7 +31,7 @@ def test__verify_convergence_order_via_MMS():
         
             self.mesh = fe.UnitSquareMesh(self.gridsize, self.gridsize)
             
-        def strong_form_residual(self):
+        def strong_form_residual(self, solution):
             
             gamma = self.pressure_penalty_factor
             
@@ -44,7 +45,7 @@ def test__verify_convergence_order_via_MMS():
             
             grad, dot, div, sym = fe.grad, fe.dot, fe.div, fe.sym
             
-            p, u, T = self.manufactured_solution()
+            p, u, T = solution
             
             r_p = div(u) + gamma*p
             
@@ -74,9 +75,9 @@ def test__verify_convergence_order_via_MMS():
             
             return p, u, T
             
-    fem.mms.verify_order_of_accuracy(
+    fem.mms.verify_spatial_order_of_accuracy(
         Model = Model,
-        expected_spatial_order = 2,
-        grid_sizes = (2, 4, 8, 16, 32),
-        tolerance = 0.1)
+        expected_order = 2,
+        grid_sizes = grid_sizes,
+        tolerance = tolerance)
     

--- a/tests/test__navier_stokes_boussinesq.py
+++ b/tests/test__navier_stokes_boussinesq.py
@@ -3,7 +3,7 @@ import fem
 
 
 def test__verify_convergence_order_via_MMS(
-        grid_sizes = (16, 32), tolerance = 0.1):
+        grid_sizes = (16, 32), tolerance = 0.1, quadrature_degree = 4):
     
     class Model(fem.models.navier_stokes_boussinesq.Model):
     
@@ -13,23 +13,41 @@ def test__verify_convergence_order_via_MMS(
             
             super().__init__()
             
-            self.integration_measure = fe.dx(degree = 4)
-            
             self.dynamic_viscosity.assign(0.1)
         
             self.rayleigh_number.assign(10.)
             
             self.prandtl_number(0.7)
             
-            ihat, jhat = self.unit_vectors()
-            
-            self.gravity_direction.assign(-jhat)
-            
             self.pressure_penalty_factor.assign(1.e-7)
             
         def init_mesh(self):
         
             self.mesh = fe.UnitSquareMesh(self.gridsize, self.gridsize)
+            
+        def init_integration_measure(self):
+
+            self.integration_measure = fe.dx(degree = 4)
+            
+        def init_manufactured_solution(self):
+            
+            sin, pi = fe.sin, fe.pi
+            
+            x = fe.SpatialCoordinate(self.mesh)
+            
+            u0 = sin(2.*pi*x[0])*sin(pi*x[1])
+            
+            u1 = sin(pi*x[0])*sin(2.*pi*x[1])
+            
+            ihat, jhat = self.unit_vectors()
+            
+            u = u0*ihat + u1*jhat
+            
+            p = -0.5*(u0**2 + u1**2)
+            
+            T = sin(2.*pi*x[0])*sin(pi*x[1])
+            
+            self.manufactured_solution = p, u, T
             
         def strong_form_residual(self, solution):
             
@@ -54,30 +72,11 @@ def test__verify_convergence_order_via_MMS(
             r_T = dot(u, grad(T)) - 1./Pr*div(grad(T))
             
             return r_p, r_u, r_T
-        
-        def manufactured_solution(self):
-            
-            sin, pi = fe.sin, fe.pi
-            
-            x = fe.SpatialCoordinate(self.mesh)
-            
-            u0 = sin(2.*pi*x[0])*sin(pi*x[1])
-            
-            u1 = sin(pi*x[0])*sin(2.*pi*x[1])
-            
-            ihat, jhat = self.unit_vectors()
-            
-            u = u0*ihat + u1*jhat
-            
-            p = -0.5*(u0**2 + u1**2)
-            
-            T = sin(2.*pi*x[0])*sin(pi*x[1])
-            
-            return p, u, T
             
     fem.mms.verify_spatial_order_of_accuracy(
         Model = Model,
         expected_order = 2,
         grid_sizes = grid_sizes,
-        tolerance = tolerance)
+        tolerance = tolerance,
+        quadrature_degree = quadrature_degree)
     

--- a/tests/test__navier_stokes_boussinesq.py
+++ b/tests/test__navier_stokes_boussinesq.py
@@ -77,6 +77,5 @@ def test__verify_convergence_order_via_MMS(
         Model = Model,
         expected_order = 2,
         grid_sizes = grid_sizes,
-        tolerance = tolerance,
-        quadrature_degree = quadrature_degree)
+        tolerance = tolerance)
     


### PR DESCRIPTION
- Consistently have init methods across the board, rather than the mixed approach. So far this new design seems to be the most easily extensible.
- Add abstract class for unsteady models
- Add heat model, verified both with first and second order time discretization methods
- Remove quadrature_degree from MMS interface, instead having the model class define a integration_measure
- Cleaned up some docstrings